### PR TITLE
Snakefile: Fix typo in 'wildcard[s]'

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -242,7 +242,7 @@ rule split_images:
                **split_outer_product)
     shell: '''
     wirecell-util frame-split \
-    -f data/images/{wildcard.domain}/{{detector}}-{{tag}}-{{index}}-{{anodeid}}-{{plane}}.npz \
+    -f data/images/{wildcards.domain}/{{detector}}-{{tag}}-{{index}}-{{anodeid}}-{{plane}}.npz \
     {input}
     '''
 


### PR DESCRIPTION
As of commit 63a06627d0b0a04b52fc56ff72acc4306c02d501 I am seeing the following error in rule `split_images`:
```
RuleException in line 237 of toyzero/Snakefile:
NameError: The name 'wildcard' is unknown in this context. Please make sure that you defined that variable. Also note that braces not used for variable access have to be escaped by repeating them, i.e. {{print $1}}
```

This is likely due to a typo in `wildcard`. This PR fixes the typo and makes snakemake run a little bit longer.