### PR TITLE
Plane fix

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -242,7 +242,7 @@ rule split_images:
                **split_outer_product)
     shell: '''
     wirecell-util frame-split \
-    -f data/images/{wildcard.domain}/{{detector}}-{{tag}}-{{index}}-{{anodeid}}-{{plane}}.npz \
+    -f data/images/{wildcards.domain}/{{detector}}-{{tag}}-{{index}}-{{anodeid}}-{{plane}}.npz \
     {input}
     '''
 

--- a/Snakefile
+++ b/Snakefile
@@ -242,7 +242,7 @@ rule split_images:
                **split_outer_product)
     shell: '''
     wirecell-util frame-split \
-    -f data/images/{wildcards.domain}/{{detector}}-{{tag}}-{{index}}-{{anodeid}}-{{plane}}.npz \
+    -f data/images/{wildcards.domain}/{{detector}}-{{tag}}-{{index}}-{{anodeid}}-{{planeletter}}.npz \
     {input}
     '''
 


### PR DESCRIPTION
Same as in wildcard issue, but now it fails with:
```
  File "toyzero/src/wirecell/wirecell/util/main.py", line 540, in frame_split_protodune
    path = pattern.format(**locals())
KeyError: 'plane'
```